### PR TITLE
adress removal of `is_untitled` and `create_tab_from_location` in latest Gedit API

### DIFF
--- a/restoretabs.py
+++ b/restoretabs.py
@@ -2,7 +2,7 @@
 # Distribute under GNU GPL 3.0 License.
 
 import os
-from gi.repository import GObject, GLib, Gtk, Gio, Tepl, Gedit
+from gi.repository import GObject, GLib, Gtk, Gio, Gedit
 
 SETTINGS_SCHEMA = "org.gnome.gedit.plugins.restoretabs"
 

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -74,8 +74,8 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
                     if location.query_exists():
                         tab = self.window.get_tab_from_location(location)
                         if not tab:
-                            self.window.create_tab_from_location(location, None, 0, 
-                                                                    0, False, True)
+                            tab = self.window.create_tab(True) #create new tab and jump_to it
+                            tab.load_file(location, None, 0, 0, True) #GFile *location,*encoding,line_pos,column_pos,create
             self.window.disconnect(self._temp_handler)
 
 
@@ -85,12 +85,13 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
             Remove handler after first use.
             """
             document = tab.get_document()
-            if document.is_untitled() and len(window.get_documents()) > 1:
-                # crash with segfault
-                #self.window.close_tab(tab)
-                # workaround
-                source_id = GObject.idle_add(self.tabclose, tab)
-                self.window.disconnect(self.tab_handler_id)
+#            if document.is_untitled() and len(window.get_documents()) > 1:
+#                # crash with segfault
+#                #self.window.close_tab(tab)
+#                # workaround
+#                print("----------------closing tab")
+#                source_id = GObject.idle_add(self.tabclose, tab)
+#                self.window.disconnect(self.tab_handler_id)
 
     def tabclose(self, tab):
             self.window.close_tab(tab)


### PR DESCRIPTION
attempt to update the code based removal of `is_untitled` and `is_untitled` in latest Gedit API.
as discussed in https://github.com/raelgc/gedit-restore-tabs/issues/14

Disclaimer: This is the first time I'm touching a Gedit plugin. It works fine for me on gedit - Version 46.2 but please double check as there may be edge cases I haven't checked.

See references:
- is_untitled: https://gitlab.gnome.org/World/gedit/gedit/-/blob/master/docs/reference/api-breaks.xml#L164
proposed to detect get_location() `NULL`

- create_tab_from_location breaking change: https://gitlab.gnome.org/World/gedit/gedit/-/blob/master/docs/reference/api-breaks.xml#L121-129
proposed to use create_tab followed by load_file. However, the "tab-added" event only gets triggered on create_tab at which point the document is not loaded so all files are deemed untitled. Instead, proposing to record the number of documents to be opened and catch the last "tab-added" generated by the extra Untitled Document tab

